### PR TITLE
Add write support for FlatGeobuf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,34 @@ julia> DataFrame(fgb)
 │ 2   │ USA    │ United States of America │
 ```
 
-# TODO
-* Write support
+## Writing FlatGeobuf files
+
+Write an existing FlatGeobuffer back to disk:
+```julia
+fgb = FGB.read("countries.fgb")
+FGB.write("countries_copy.fgb", fgb)
+```
+
+Write any Tables.jl-compatible table with GeoInterface geometries:
+```julia
+using DataFrames
+
+# Create a DataFrame with geometries
+df = DataFrame(
+    name = ["A", "B", "C"],
+    value = [1.0, 2.0, 3.0],
+    geometry = [point1, point2, point3]  # Any GeoInterface-compatible geometries
+)
+
+FGB.write("points.fgb", df)
+```
+
+Optional parameters:
+- `geometrycolumn`: Name of the geometry column (defaults to `GeoInterface.geometrycolumns(table)` or `:geometry`)
+- `crs`: Coordinate reference system (defaults to `GeoInterface.crs(table)`, or e.g., `GeoFormatTypes.EPSG(4326)`)
+- `name`: Dataset name for the header
+
+Note: Spatial index generation is not yet supported; written files will not have an R-tree index.
 
 # Updating the Schema
 I've used https://github.com/rjkat/flatbuffers-julia to autogenerate the files found in `src/schema`, but had to adapt them. Good autogeneration from schema is broken as of now. Probably needs waiting on a 1.6/1.7 Julia release so https://github.com/JuliaLang/julia/pull/32658 is merged, so an official flatbuffer implementation can be made over at https://github.com/google/flatbuffers/pull/5088.

--- a/src/FlatGeobuf.jl
+++ b/src/FlatGeobuf.jl
@@ -11,6 +11,7 @@ include("index.jl")
 include("io.jl")
 include("table.jl")
 include("geointerface.jl")
+include("write.jl")
 
 
 end # module

--- a/src/write.jl
+++ b/src/write.jl
@@ -1,0 +1,462 @@
+
+# Magic bytes for FlatGeobuf format
+const MAGIC_BYTES = UInt8[0x66, 0x67, 0x62, 0x03, 0x66, 0x67, 0x62, 0x00]
+
+# Reverse lookup: Julia type -> ColumnType
+const reverse_lookup = Dict(
+    Int8 => ColumnTypeByte,
+    UInt8 => ColumnTypeUByte,
+    Bool => ColumnTypeBool,
+    Int16 => ColumnTypeShort,
+    UInt16 => ColumnTypeUShort,
+    Int32 => ColumnTypeInt,
+    UInt32 => ColumnTypeUInt,
+    Int64 => ColumnTypeLong,
+    UInt64 => ColumnTypeULong,
+    Float32 => ColumnTypeFloat,
+    Float64 => ColumnTypeDouble,
+    String => ColumnTypeString,
+)
+
+# GeoInterface trait -> FlatGeobuf GeometryType
+const trait_to_geomtype = Dict(
+    GeoInterface.PointTrait() => GeometryTypePoint,
+    GeoInterface.LineStringTrait() => GeometryTypeLineString,
+    GeoInterface.PolygonTrait() => GeometryTypePolygon,
+    GeoInterface.MultiPointTrait() => GeometryTypeMultiPoint,
+    GeoInterface.MultiLineStringTrait() => GeometryTypeMultiLineString,
+    GeoInterface.MultiPolygonTrait() => GeometryTypeMultiPolygon,
+    GeoInterface.GeometryCollectionTrait() => GeometryTypeGeometryCollection,
+)
+
+# Convert GeoFormatTypes CRS wrappers to FlatGeobuf Crs
+Base.convert(::Type{Crs}, ::Nothing) = Crs()
+Base.convert(::Type{Crs}, crs::Crs) = crs
+Base.convert(::Type{Crs}, crs::GeoFormatTypes.EPSG) = Crs(org="EPSG", code=Int32(GeoFormatTypes.val(crs)))
+Base.convert(::Type{Crs}, crs::GeoFormatTypes.AbstractWellKnownText) = Crs(wkt=string(GeoFormatTypes.val(crs)))
+
+"""
+    write_magic(io::IO)
+
+Write the 8-byte FlatGeobuf magic header.
+"""
+function write_magic(io::IO)
+    Base.write(io, MAGIC_BYTES)
+end
+
+"""
+    write_header(io::IO, header::Header)
+
+Write a size-prefixed Header FlatBuffer to the IO stream.
+"""
+function write_header(io::IO, header::Header)
+    # Serialize header to bytes
+    buf = IOBuffer()
+    FlatBuffers.serialize(buf, header)
+    header_bytes = take!(buf)
+
+    # Write size prefix (UInt32) then header bytes
+    Base.write(io, UInt32(length(header_bytes)))
+    Base.write(io, header_bytes)
+end
+
+"""
+    encode_properties(props::NamedTuple, columns::Vector{Column})
+
+Encode properties to the FlatGeobuf binary property format.
+"""
+function encode_properties(props::NamedTuple, columns::Vector{Column})
+    buf = IOBuffer()
+    for (i, col) in enumerate(columns)
+        name = Symbol(col.name)
+        haskey(props, name) || continue
+        val = getproperty(props, name)
+        ismissing(val) && continue  # Skip missing values
+
+        Base.write(buf, UInt16(i - 1))  # 0-indexed column index
+
+        T = lookup[col.type]
+        if T == String
+            bytes = Vector{UInt8}(val)
+            Base.write(buf, UInt32(length(bytes)))
+            Base.write(buf, bytes)
+        else
+            Base.write(buf, T(val))  # Fixed-size numeric
+        end
+    end
+    take!(buf)
+end
+
+"""
+    encode_properties(feature::Feature)
+
+Encode properties from an existing Feature.
+"""
+function encode_properties(feature::Feature)
+    props = split_properties(feature.properties, feature.columns)
+    encode_properties(props, feature.columns)
+end
+
+"""
+    write_feature(io::IO, feature::Feature)
+
+Write a size-prefixed Feature FlatBuffer to the IO stream.
+"""
+function write_feature(io::IO, feature::Feature)
+    # Serialize feature to bytes
+    buf = IOBuffer()
+    FlatBuffers.serialize(buf, feature)
+    feature_bytes = take!(buf)
+
+    # Write size prefix (UInt32) then feature bytes
+    Base.write(io, UInt32(length(feature_bytes)))
+    Base.write(io, feature_bytes)
+end
+
+"""
+    write(filename::AbstractString, fgb::FlatGeobuffer)
+
+Write a FlatGeobuffer to a file.
+"""
+function write(filename::AbstractString, fgb::FlatGeobuffer)
+    open(filename, "w") do io
+        write(io, fgb)
+    end
+    filename
+end
+
+"""
+    write(io::IO, fgb::FlatGeobuffer)
+
+Write a FlatGeobuffer to an IO stream.
+"""
+function write(io::IO, fgb::FlatGeobuffer)
+    # Write magic bytes
+    write_magic(io)
+
+    # Prepare header - update feature count and disable index
+    header = fgb.header
+    header.index_node_size = UInt16(0)  # No index for now
+
+    # Write header
+    write_header(io, header)
+
+    # Write all features
+    for feature in fgb
+        write_feature(io, feature)
+    end
+
+    nothing
+end
+
+# =============================================================================
+# GeoInterface geometry conversion
+# =============================================================================
+
+"""
+    convert_geometry(geom) -> Geometry
+
+Convert any GeoInterface-compatible geometry to a FlatGeobuf Geometry.
+"""
+function convert_geometry(geom)
+    trait = GeoInterface.geomtrait(geom)
+    convert_geometry(trait, geom)
+end
+
+# Point
+function convert_geometry(::GeoInterface.PointTrait, geom)
+    ncoord = GeoInterface.ncoord(geom)
+    xy = Float64[GeoInterface.getcoord(geom, 1), GeoInterface.getcoord(geom, 2)]
+    z = ncoord >= 3 ? Float64[GeoInterface.getcoord(geom, 3)] : Float64[]
+    m = ncoord >= 4 ? Float64[GeoInterface.getcoord(geom, 4)] : Float64[]
+    Geometry(ends=UInt32[], xy=xy, z=z, m=m, t=Float64[], tm=UInt64[], type=GeometryTypePoint, parts=Geometry[])
+end
+
+# LineString
+function convert_geometry(::GeoInterface.LineStringTrait, geom)
+    npts = GeoInterface.ngeom(geom)
+    xy = Float64[]
+    z = Float64[]
+    m = Float64[]
+    has_z = false
+    has_m = false
+
+    for i in 1:npts
+        pt = GeoInterface.getgeom(geom, i)
+        ncoord = GeoInterface.ncoord(pt)
+        push!(xy, GeoInterface.getcoord(pt, 1))
+        push!(xy, GeoInterface.getcoord(pt, 2))
+        if ncoord >= 3
+            has_z = true
+            push!(z, GeoInterface.getcoord(pt, 3))
+        end
+        if ncoord >= 4
+            has_m = true
+            push!(m, GeoInterface.getcoord(pt, 4))
+        end
+    end
+
+    Geometry(ends=UInt32[], xy=xy, z=has_z ? z : Float64[], m=has_m ? m : Float64[],
+             t=Float64[], tm=UInt64[], type=GeometryTypeLineString, parts=Geometry[])
+end
+
+# Polygon
+function convert_geometry(::GeoInterface.PolygonTrait, geom)
+    nrings = GeoInterface.ngeom(geom)
+    xy = Float64[]
+    z = Float64[]
+    m = Float64[]
+    ends = UInt32[]
+    has_z = false
+    has_m = false
+    coord_count = 0
+
+    for i in 1:nrings
+        ring = GeoInterface.getgeom(geom, i)
+        npts = GeoInterface.ngeom(ring)
+        for j in 1:npts
+            pt = GeoInterface.getgeom(ring, j)
+            ncoord = GeoInterface.ncoord(pt)
+            push!(xy, GeoInterface.getcoord(pt, 1))
+            push!(xy, GeoInterface.getcoord(pt, 2))
+            if ncoord >= 3
+                has_z = true
+                push!(z, GeoInterface.getcoord(pt, 3))
+            end
+            if ncoord >= 4
+                has_m = true
+                push!(m, GeoInterface.getcoord(pt, 4))
+            end
+            coord_count += 1
+        end
+        push!(ends, UInt32(coord_count))
+    end
+
+    Geometry(ends=ends, xy=xy, z=has_z ? z : Float64[], m=has_m ? m : Float64[],
+             t=Float64[], tm=UInt64[], type=GeometryTypePolygon, parts=Geometry[])
+end
+
+# MultiPoint
+function convert_geometry(::GeoInterface.MultiPointTrait, geom)
+    npts = GeoInterface.ngeom(geom)
+    xy = Float64[]
+    z = Float64[]
+    m = Float64[]
+    has_z = false
+    has_m = false
+
+    for i in 1:npts
+        pt = GeoInterface.getgeom(geom, i)
+        ncoord = GeoInterface.ncoord(pt)
+        push!(xy, GeoInterface.getcoord(pt, 1))
+        push!(xy, GeoInterface.getcoord(pt, 2))
+        if ncoord >= 3
+            has_z = true
+            push!(z, GeoInterface.getcoord(pt, 3))
+        end
+        if ncoord >= 4
+            has_m = true
+            push!(m, GeoInterface.getcoord(pt, 4))
+        end
+    end
+
+    Geometry(ends=UInt32[], xy=xy, z=has_z ? z : Float64[], m=has_m ? m : Float64[],
+             t=Float64[], tm=UInt64[], type=GeometryTypeMultiPoint, parts=Geometry[])
+end
+
+# MultiLineString
+function convert_geometry(::GeoInterface.MultiLineStringTrait, geom)
+    nlines = GeoInterface.ngeom(geom)
+    xy = Float64[]
+    z = Float64[]
+    m = Float64[]
+    ends = UInt32[]
+    has_z = false
+    has_m = false
+    coord_count = 0
+
+    for i in 1:nlines
+        line = GeoInterface.getgeom(geom, i)
+        npts = GeoInterface.ngeom(line)
+        for j in 1:npts
+            pt = GeoInterface.getgeom(line, j)
+            ncoord = GeoInterface.ncoord(pt)
+            push!(xy, GeoInterface.getcoord(pt, 1))
+            push!(xy, GeoInterface.getcoord(pt, 2))
+            if ncoord >= 3
+                has_z = true
+                push!(z, GeoInterface.getcoord(pt, 3))
+            end
+            if ncoord >= 4
+                has_m = true
+                push!(m, GeoInterface.getcoord(pt, 4))
+            end
+            coord_count += 1
+        end
+        push!(ends, UInt32(coord_count))
+    end
+
+    Geometry(ends=ends, xy=xy, z=has_z ? z : Float64[], m=has_m ? m : Float64[],
+             t=Float64[], tm=UInt64[], type=GeometryTypeMultiLineString, parts=Geometry[])
+end
+
+# MultiPolygon - uses parts for nested structure
+function convert_geometry(::GeoInterface.MultiPolygonTrait, geom)
+    npolys = GeoInterface.ngeom(geom)
+    parts = Geometry[]
+
+    for i in 1:npolys
+        poly = GeoInterface.getgeom(geom, i)
+        push!(parts, convert_geometry(GeoInterface.PolygonTrait(), poly))
+    end
+
+    Geometry(ends=UInt32[], xy=Float64[], z=Float64[], m=Float64[],
+             t=Float64[], tm=UInt64[], type=GeometryTypeMultiPolygon, parts=parts)
+end
+
+# GeometryCollection
+function convert_geometry(::GeoInterface.GeometryCollectionTrait, geom)
+    ngeoms = GeoInterface.ngeom(geom)
+    parts = Geometry[]
+
+    for i in 1:ngeoms
+        subgeom = GeoInterface.getgeom(geom, i)
+        push!(parts, convert_geometry(subgeom))
+    end
+
+    Geometry(ends=UInt32[], xy=Float64[], z=Float64[], m=Float64[],
+             t=Float64[], tm=UInt64[], type=GeometryTypeGeometryCollection, parts=parts)
+end
+
+# =============================================================================
+# Tables.jl write support
+# =============================================================================
+
+"""
+    julia_type_to_columntype(T::Type)
+
+Convert a Julia type to a FlatGeobuf ColumnType.
+"""
+function julia_type_to_columntype(T::Type)
+    # Handle Union{Missing, T}
+    if T isa Union
+        T = Base.nonmissingtype(T)
+    end
+    get(reverse_lookup, T, ColumnTypeString)  # Default to String
+end
+
+"""
+    infer_columns(table, geom_column::Symbol)
+
+Infer FlatGeobuf columns from a Tables.jl-compatible table.
+Returns (columns, geometry_column_name).
+"""
+function infer_columns(table, geom_column::Symbol)
+    sch = Tables.schema(table)
+    columns = Column[]
+
+    for (name, T) in zip(sch.names, sch.types)
+        name == geom_column && continue  # Skip geometry column
+        col_type = julia_type_to_columntype(T)
+        nullable = T isa Union && Missing <: T
+        push!(columns, Column(name=string(name), type=col_type, nullable=nullable))
+    end
+
+    columns
+end
+
+"""
+    detect_geometry_type(table, geom_column::Symbol)
+
+Detect the geometry type from the first feature in the table.
+"""
+function detect_geometry_type(table, geom_column::Symbol)
+    for row in Tables.rows(table)
+        geom = Tables.getcolumn(row, geom_column)
+        trait = GeoInterface.geomtrait(geom)
+        return get(trait_to_geomtype, trait, GeometryTypeUnknown)
+    end
+    GeometryTypeUnknown
+end
+
+"""
+    write(filename::AbstractString, table; geometrycolumn=first(GeoInterface.geometrycolumns(table)), crs=GeoInterface.crs(table), name::AbstractString="")
+
+Write a Tables.jl-compatible table to a FlatGeobuf file.
+
+The table must have a geometry column containing GeoInterface-compatible geometries.
+
+# Arguments
+- `geometrycolumn`: Name of the geometry column. Defaults to `first(GeoInterface.geometrycolumns(table))`.
+- `crs`: Coordinate reference system. Defaults to `GeoInterface.crs(table)`.
+- `name`: Dataset name for the header.
+"""
+function write(filename::AbstractString, table; geometrycolumn=first(GeoInterface.geometrycolumns(table)), crs=GeoInterface.crs(table), name::AbstractString="")
+    open(filename, "w") do io
+        write(io, table; geometrycolumn=geometrycolumn, crs=crs, name=name)
+    end
+    filename
+end
+
+"""
+    write(io::IO, table; geometrycolumn=first(GeoInterface.geometrycolumns(table)), crs=GeoInterface.crs(table), name::AbstractString="")
+
+Write a Tables.jl-compatible table to an IO stream in FlatGeobuf format.
+"""
+function write(io::IO, table; geometrycolumn=first(GeoInterface.geometrycolumns(table)), crs=GeoInterface.crs(table), name::AbstractString="")
+    geom_column = geometrycolumn
+
+    rows = Tables.rows(table)
+
+    # Collect rows to get count and detect geometry type
+    collected_rows = collect(rows)
+    features_count = length(collected_rows)
+
+    # Infer schema
+    columns = infer_columns(table, geom_column)
+    geometry_type = detect_geometry_type(table, geom_column)
+
+    # Detect coordinate dimensions from first geometry
+    has_z = false
+    has_m = false
+    if features_count > 0
+        first_geom = Tables.getcolumn(collected_rows[1], geom_column)
+        ncoord = GeoInterface.ncoord(first_geom)
+        has_z = ncoord >= 3
+        has_m = ncoord >= 4
+    end
+
+    # Build header
+    header = Header(
+        name=name,
+        geometry_type=geometry_type,
+        has_z=has_z,
+        has_m=has_m,
+        columns=columns,
+        features_count=UInt64(features_count),
+        index_node_size=UInt16(0),  # No index
+        crs=convert(Crs, crs)
+    )
+
+    # Write magic and header
+    write_magic(io)
+    write_header(io, header)
+
+    # Write features
+    col_names = Tuple(Symbol(col.name) for col in columns)
+    for row in collected_rows
+        geom = Tables.getcolumn(row, geom_column)
+        fgb_geom = convert_geometry(geom)
+
+        # Build properties as NamedTuple
+        prop_values = [Tables.getcolumn(row, name) for name in col_names]
+        props = NamedTuple{col_names}(Tuple(prop_values))
+        props_bytes = encode_properties(props, columns)
+
+        # Create and write feature
+        feature = Feature(geometry=fgb_geom, properties=props_bytes, columns=Column[])
+        write_feature(io, feature)
+    end
+
+    nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,137 @@ using GeoInterface
     isfile(fna) || Downloads.download("https://github.com/bjornharrtell/flatgeobuf/blob/master/test/data/countries.fgb?raw=true", fna)
     isfile(fnb) || Downloads.download("https://github.com/bjornharrtell/flatgeobuf/blob/master/test/data/UScounties.fgb?raw=true", fnb)
 
+    @testset "Write and round-trip" begin
+        # Read original file
+        fgb = FlatGeobuf.read(fna)
+        original_features = collect(fgb)
+
+        # Write to new file
+        outfile = tempname() * ".fgb"
+        FlatGeobuf.write(outfile, fgb)
+
+        # Read back
+        fgb2 = FlatGeobuf.read(outfile)
+        roundtrip_features = collect(fgb2)
+
+        # Compare
+        @test length(roundtrip_features) == length(original_features)
+        @test fgb2.header.name == fgb.header.name
+        @test fgb2.header.geometry_type == fgb.header.geometry_type
+        @test length(fgb2.header.columns) == length(fgb.header.columns)
+
+        # Compare first feature geometry
+        @test original_features[1].geometry == roundtrip_features[1].geometry
+
+        # Compare properties
+        for i in 1:min(5, length(original_features))
+            orig_props = FlatGeobuf.split_properties(original_features[i].properties, original_features[i].columns)
+            rt_props = FlatGeobuf.split_properties(roundtrip_features[i].properties, roundtrip_features[i].columns)
+            @test orig_props == rt_props
+        end
+
+        # Clean up
+        rm(outfile)
+    end
+
+    @testset "Write with missing values" begin
+        # Test file with null values
+        fgb = FlatGeobuf.read(joinpath(@__DIR__, "null.fgb"))
+        original_features = collect(fgb)
+
+        outfile = tempname() * ".fgb"
+        FlatGeobuf.write(outfile, fgb)
+
+        fgb2 = FlatGeobuf.read(outfile)
+        roundtrip_features = collect(fgb2)
+
+        @test length(roundtrip_features) == length(original_features)
+
+        # Verify missing values are preserved
+        t_orig = DataFrame(FlatGeobuf.read(joinpath(@__DIR__, "null.fgb")))
+        t_rt = DataFrame(fgb2)
+        @test ismissing(t_rt.date[2]) == ismissing(t_orig.date[2])
+        @test ismissing(t_rt.name[2]) == ismissing(t_orig.name[2])
+
+        rm(outfile)
+    end
+
+    @testset "Write from DataFrame with GeoInterface geometries" begin
+        # Create a simple DataFrame with point geometries
+        # Using FlatGeobuf's own Geometry type which implements GeoInterface
+        geom1 = FlatGeobuf.Geometry(xy=[1.0, 2.0], type=FlatGeobuf.GeometryTypePoint)
+        geom2 = FlatGeobuf.Geometry(xy=[3.0, 4.0], type=FlatGeobuf.GeometryTypePoint)
+        geom3 = FlatGeobuf.Geometry(xy=[5.0, 6.0], type=FlatGeobuf.GeometryTypePoint)
+
+        df = DataFrame(
+            name = ["A", "B", "C"],
+            value = [1.0, 2.0, 3.0],
+            geometry = [geom1, geom2, geom3]
+        )
+
+        outfile = tempname() * ".fgb"
+        FlatGeobuf.write(outfile, df)
+
+        # Read back and verify
+        fgb = FlatGeobuf.read(outfile)
+        @test length(fgb) == 3
+        @test fgb.header.geometry_type == FlatGeobuf.GeometryTypePoint
+
+        features = collect(fgb)
+        @test features[1].geometry.xy == [1.0, 2.0]
+        @test features[2].geometry.xy == [3.0, 4.0]
+        @test features[3].geometry.xy == [5.0, 6.0]
+
+        # Check properties
+        df_rt = DataFrame(fgb)
+        @test df_rt.name == ["A", "B", "C"]
+        @test df_rt.value == [1.0, 2.0, 3.0]
+
+        rm(outfile)
+    end
+
+    @testset "Write polygon geometries" begin
+        # Create a polygon (triangle)
+        poly = FlatGeobuf.Geometry(
+            xy=[0.0, 0.0, 1.0, 0.0, 0.5, 1.0, 0.0, 0.0],
+            ends=UInt32[4],
+            type=FlatGeobuf.GeometryTypePolygon
+        )
+
+        df = DataFrame(
+            id = [1],
+            geometry = [poly]
+        )
+
+        outfile = tempname() * ".fgb"
+        FlatGeobuf.write(outfile, df)
+
+        fgb = FlatGeobuf.read(outfile)
+        @test length(fgb) == 1
+        @test fgb.header.geometry_type == FlatGeobuf.GeometryTypePolygon
+
+        features = collect(fgb)
+        @test features[1].geometry.xy == [0.0, 0.0, 1.0, 0.0, 0.5, 1.0, 0.0, 0.0]
+        @test features[1].geometry.ends == UInt32[4]
+
+        rm(outfile)
+    end
+
+    @testset "GeoInterface geometry conversion" begin
+        # Test that we can convert existing FlatGeobuf geometries
+        # (which implement GeoInterface) through our conversion functions
+        fgb = FlatGeobuf.read(fna)
+        features = collect(fgb)
+
+        # Convert MultiPolygon and back
+        orig_geom = features[1].geometry
+        converted = FlatGeobuf.convert_geometry(orig_geom)
+
+        @test converted.type == orig_geom.type
+        # For MultiPolygon, parts should match
+        @test length(converted.parts) == length(orig_geom.parts)
+    end
+
     @testset "Construction" begin
         crs = FlatGeobuf.Crs("epsg", 28992, "RD New", "Dutch grid", "proj+=asdas", "codestring")
         h = FlatGeobuf.Header(name="test", crs=crs)


### PR DESCRIPTION
## Summary
- Implements writing FlatGeobuf files to disk
- Adds support for writing any Tables.jl-compatible table with GeoInterface geometries
- Includes round-trip tests to verify correctness

## Features
- Basic write functions for magic bytes, headers, and features
- Property encoding in the FlatGeobuf binary format  
- GeoInterface geometry conversion for Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection
- Tables.jl write support with automatic schema inference
- Optional CRS specification via GeoFormatTypes

## Test plan
- [x] Round-trip existing FlatGeobuf files (countries.fgb)
- [x] Round-trip files with missing/null values
- [x] Write DataFrame with Point geometries
- [x] Write DataFrame with Polygon geometries  
- [x] GeoInterface geometry conversion for MultiPolygon

## Note
Spatial index (R-tree) generation is not yet implemented; written files will not have an index for bbox queries. This can be added in a follow-up PR.

Generated with [Claude Code](https://claude.com/claude-code)